### PR TITLE
Removal of master/slave phrasing

### DIFF
--- a/apps/classroom/migrations/0001_initial.py
+++ b/apps/classroom/migrations/0001_initial.py
@@ -20,8 +20,8 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=127, unique=True, verbose_name='名称')),
                 ('grade', models.PositiveSmallIntegerField(choices=[(0, '1年级'), (1, '2年级'), (0, '3年级'), (0, '4年级'), (0, '5年级'), (0, '6年级')], default=0, verbose_name='年级')),
                 ('create_date', models.DateTimeField(auto_now_add=True, verbose_name='创建时间')),
-                ('master_teacher', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='master_teacher', to='role.Teacher', verbose_name='班主任')),
-                ('slave_teacher', models.ManyToManyField(related_name='slave_teacher', to='role.Teacher', verbose_name='辅助老师')),
+                ('main_teacher', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='main_teacher', to='role.Teacher', verbose_name='班主任')),
+                ('subordinate_teacher', models.ManyToManyField(related_name='subordinate_teacher', to='role.Teacher', verbose_name='辅助老师')),
                 ('students', models.ManyToManyField(to='role.Student', verbose_name='学生')),
             ],
             options={

--- a/apps/classroom/migrations/0003_auto_20200701_2351.py
+++ b/apps/classroom/migrations/0003_auto_20200701_2351.py
@@ -13,13 +13,13 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterField(
             model_name='classroom',
-            name='master_teacher',
-            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='master_teacher', to='institution.InstTeacher', verbose_name='班主任'),
+            name='main_teacher',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='main_teacher', to='institution.InstTeacher', verbose_name='班主任'),
         ),
         migrations.AlterField(
             model_name='classroom',
-            name='slave_teacher',
-            field=models.ManyToManyField(related_name='slave_teacher', to='institution.InstTeacher', verbose_name='辅助老师'),
+            name='subordinate_teacher',
+            field=models.ManyToManyField(related_name='subordinate_teacher', to='institution.InstTeacher', verbose_name='辅助老师'),
         ),
         migrations.AlterField(
             model_name='classroom',

--- a/apps/classroom/models.py
+++ b/apps/classroom/models.py
@@ -21,8 +21,8 @@ class Classroom(models.Model):
     institution = models.ForeignKey(Institution, verbose_name="机构", on_delete=models.CASCADE, null=True)
 
     packages = models.ManyToManyField(Package, verbose_name="所上课程")
-    master_teacher = models.ForeignKey(InstTeacher, verbose_name="班主任", on_delete=models.SET_NULL, related_name="master_teacher", blank=True, null=True)
-    slave_teacher = models.ManyToManyField(InstTeacher, verbose_name="辅助老师", related_name="slave_teacher")
+    main_teacher = models.ForeignKey(InstTeacher, verbose_name="班主任", on_delete=models.SET_NULL, related_name="main_teacher", blank=True, null=True)
+    subordinate_teacher = models.ManyToManyField(InstTeacher, verbose_name="辅助老师", related_name="subordinate_teacher")
 
     students = models.ManyToManyField(InstStudent, verbose_name="学生")
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.